### PR TITLE
Fail if lmbench test fails, and make it easy to enable/disable tests

### DIFF
--- a/lmbench-regression
+++ b/lmbench-regression
@@ -55,7 +55,8 @@ then	FSDIR=/tmp/lat_fs
 fi
 MP=N
 
-# Figure out as much stuff as we can about this system.
+
+ Figure out as much stuff as we can about this system.
 # Sure would be nice if everyone had SGI's "hinv".
 echo \[lmbench2.0 results for `uname -a`] 1>&2
 echo \[ALL: ${ALL}] 1>&2
@@ -115,126 +116,158 @@ then	echo "Can't make a file - $STAT - in $FSDIR"
 	exit 1
 fi
 
+cp hello /tmp/hello
+
 function run {
 	echo "$@"
 	TMPOUT=/tmp/OUT
 	rm -rf $TMPOUT
-	$LOADER "$@" 2>>$TMPOUT | tee -a $TMPOUT
-	echo $?
-	echo "Done"
-	if [ $? -ne 0 ]
+	$LOADER "$@" >>$TMPOUT 2>&1
+	retval=$?
+	echo $retval
+#	echo $?
+#	echo "Done"
+	if [ $retval -ne 0 ]
 	then
 	    cat $TMPOUT 1>&2
 	    exit 1
 	else
 	    cat $TMPOUT 1>&2
 	fi
+
 }
 
-date
-echo Latency measurements
-msleep 250
-run lat_syscall null
-run lat_syscall read
-run lat_syscall write
-run lat_syscall stat $STAT
-run lat_syscall fstat $STAT
-run lat_syscall open $STAT
-
-#select file (500), select tcp (500)
-run lat_select file 500
-
-# DP 1/20/18: This test intermittently hangs on SGX, taking out of CI for now
-#run lat_select tcp 500
-
-#sig install, sig_overhead, prot. Fault
-run lat_sig install
-run lat_sig catch
-run lat_sig prot lat_sig
-
+function af_unix {
 # DP 7/4/18: This test intermittently hangs on SGX, taking out of CI for now
 #AF_UNIX
-#echo AF_UNIX socket latency
-#for i in $(eval echo "{1..$N_RUNS}")
-#do	run lat_unix
-#done
+	echo AF_UNIX socket latency
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	run lat_unix
+	done
+}
 
-#forks
-cp hello /tmp/hello
-## DEP 12/9/17: Temporarily remove vfork from the unit tests
-## DEP 6/16/18: Temporarily remove shell from the unit tests
+
+function wr_bw {
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	rm -f $FILE
+		run lmdd label="File $FILE write bandwidth:" of=$FILE move=${MB}m fsync=1 print=3
+	done
+}
+
+function udp_soc_lat {
+	echo UDP socket latency
+	run lat_udp -s &
+	sleep 3
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	run lat_udp 127.0.0.1
+		sleep 1
+	done
+	run lat_udp -127.0.0.1
+	sleep 3
+}
+
+function tcp_soc_lat {
+	echo TCP socket latency
+	run lat_tcp -s &
+	sleep 3
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	run lat_tcp 127.0.0.1
+		sleep 1
+	done
+	run lat_tcp -127.0.0.1
+	sleep 3
+}
+
+function tcp_con_lat {
+	echo TCP connect latency
+	run lat_connect -s &
+	sleep 3
+	run lat_connect 127.0.0.1
+	sleep 1
+	run lat_connect -127.0.0.1
+	sleep 3
+}
+
+function tcp_soc_bw {
+	echo TCP socket bandwidth
+	run bw_tcp -s &
+	sleep 3
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	run bw_tcp 127.0.0.1
+		sleep 1
+	done
+	run bw_tcp -127.0.0.1
+	sleep 3
+}
+
+function bw_unix {
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	run bw_unix
+	done
+}
+
+function bw_pipe {
+	for i in $(eval echo "{1..$N_RUNS}")
+	do	run bw_pipe
+	done
+}
+
+
+declare -a tests=(\
+			"lat_syscall null" \
+			"lat_syscall read" \
+			"lat_syscall write" \
+			"lat_syscall stat $STAT" \
+			"lat_syscall fstat $STAT" \
+			"lat_syscall open $STAT" \
+			"lat_select file 500" \
+# DP 1/20/18: This test intermittently hangs on SGX, taking out of CI for now
+#			"lat_select tcp 500" \
+			"lat_sig install" 			"lat_sig catch" \
+			"lat_sig prot lat_sig" \
+			"lat_proc fork" \
 ## DEP 6/16/18: Temporarily remove dfork from the unit tests
-## DEP 6/19/18: Temporarily remove dforkexec from the unit tests
+#			"lat_proc dfork" \
+## DEP 12/9/17: Temporarily remove vfork from the unit tests
+#			"lat_proc vfork" \
 ## DEP 11/1/18: Temporarily remove exec from the unit tests
-#for i in fork dfork vfork exec dforkexec shell
-for i in fork 
-do	run lat_proc $i
-done
-rm -f /tmp/hello
+#			"lat_proc exec" \
+## DEP 6/19/18: Temporarily remove dforkexec from the unit tests
+#			"lat_proc dforkexec" \
+## DEP 6/16/18: Temporarily remove shell from the unit tests
+#			"lat_proc shell" \
+			"lat_fs $FSDIR"
+		);
 
-for i in $(eval echo "{1..$N_RUNS}")
-do	rm -f $FILE
-	run lmdd label="File $FILE write bandwidth:" of=$FILE move=${MB}m fsync=1 print=3
-done
-
-#0,4,10KB create/delete
-date
-	echo Calculating file system latency
-	echo '"File system latency' 1>&2
-	run lat_fs $FSDIR
-	echo "" 1>&2
-
-date
-echo Local netruning
-
-echo UDP socket latency
-run lat_udp -s &
-sleep 3
-for i in $(eval echo "{1..$N_RUNS}")
-do	run lat_udp 127.0.0.1
-	sleep 1
-done
-run lat_udp -127.0.0.1
-sleep 3
-
-echo TCP socket latency
-run lat_tcp -s &
-sleep 3
-for i in $(eval echo "{1..$N_RUNS}")
-do	run lat_tcp 127.0.0.1
-	sleep 1
-done
-run lat_tcp -127.0.0.1
-sleep 3
-
-echo TCP connect latency
-run lat_connect -s &
-sleep 3
-run lat_connect 127.0.0.1
-sleep 1
-run lat_connect -127.0.0.1
-sleep 3
-
-echo TCP socket bandwidth
-run bw_tcp -s &
-sleep 3
-for i in $(eval echo "{1..$N_RUNS}")
-do	run bw_tcp 127.0.0.1
-	sleep 1
-done
-run bw_tcp -127.0.0.1
-sleep 3
-
-date
-echo Bandwidth measurements
-
-for i in $(eval echo "{1..$N_RUNS}")
-do	run bw_unix
-done
-
+declare -a test_funcs=(\
+# DP 7/4/18: This test intermittently hangs on SGX, taking out of CI for now
+#			"af_unix" \
+			"wr_bw" \
+			"udp_soc_lat" \
+			"tcp_soc_lat" \
+			"tcp_con_lat" \
+			"tcp_soc_bw" \
+			"bw_unix" \
 ## DEP 1/20/18: Temporarliy remove bw_pipe from the unit tests - intermittent hangs
-#for i in $(eval echo "{1..$N_RUNS}")
-#do	run bw_pipe
-#done
+#			"bw_pipe" \
+		);
+
+date
+msleep 250
+
+for i in `seq 0 $((${#tests[@]}-1))`
+do 
+echo "Running ${tests[$i]}"
+run ${tests[$i]}
+done
+
+
+for i in `seq 0 $((${#test_funcs[@]}-1))`
+do
+echo "Calling ${test_funcs[$i]}"
+${test_funcs[$i]}
+done
+
+rm -f /tmp/hello
 
 exit 0


### PR DESCRIPTION
The error code of lmbench tests was getting lost due to echo $?, and echo "done".
Re-organized the tests so that each test is an entry in the array that can be enabled or disable easily.